### PR TITLE
3.1/master

### DIFF
--- a/classes/i18n/date/format.php
+++ b/classes/i18n/date/format.php
@@ -16,16 +16,7 @@ class I18n_Date_Format extends Kohana_Date
 	 * Named formats
 	 * @var array
 	 */
-	protected $_formats = array(
-		'db' => '%Y-%m-%d %H:%M:%S',
-		'compact' => '%Y%m%dT%H%M%S',
-		'header' => '%g',
-		'iso8601' => '%Y-%m-%dT%H:%M:%S%T',
-		'rfc822' => '%a, %d %b %Y %H:%M:%S %z',
-		'rfc2822' => '%r',
-		'short' => '%d %b %H:%M',
-		'long' => '%B %d, %Y %H:%M',
-	);
+	protected $_formats = array();
 	/**
 	 * @var int
 	 */

--- a/config/i18n_plural.php
+++ b/config/i18n_plural.php
@@ -2,6 +2,14 @@
 
 return array(
     'date_formats' => array(
+		'db' => '%Y-%m-%d %H:%M:%S',
+		'compact' => '%Y%m%dT%H%M%S',
+		'header' => '%g',
+		'iso8601' => '%Y-%m-%dT%H:%M:%S%T',
+		'rfc822' => '%a, %d %b %Y %H:%M:%S %z',
+		'rfc2822' => '%r',
+		'short' => '%d %b %H:%M',
+		'long' => '%B %d, %Y %H:%M',
         'article' => '%e %C %Y %H:%M'
     )
 );


### PR DESCRIPTION
Hello, Korney!
I have slightly modified the I18n_Plural. Here are the changes:
1. I added custom named date formats support by loading them in __construct() method from configuration file called same as the module.
2. I added the genitive case support for months' strings. It may be needed for some languages. For example, in Russian it would be 'Май', 'Июнь' ('May', 'June') in the nominative case but '1 Мая', '1 Июня' ('1st of May', '1st of June' and so on). So, months are still '%B' now in the nominative case but ones in the genitive case are now '%C'.

Consider this request, please.
Thank you!
